### PR TITLE
Add CryptoAML to Compliance, Risk & AML

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ These come various open source startpages, LinkedIn posts, the legendary (Stay S
 ## 🛡 Compliance, Risk & AML
 - [Chainalysis](https://www.chainalysis.com/) · [Elliptic](https://www.elliptic.co/) · [TRM Labs Blog](https://www.trmlabs.com/blog)  
 - [Coinfirm](https://www.coinfirm.com/) · [CipherTrace](https://ciphertrace.com/) · [Crystal Blockchain](https://crystalblockchain.com/)  
-- [AMLBot](https://amlbot.com/) · [Scorechain](https://www.scorechain.com/) · [Merkle Science](https://www.merklescience.com/) · [AnChain.AI](https://www.anchain.ai/)  
+- [AMLBot](https://amlbot.com/) · [Scorechain](https://www.scorechain.com/) · [Merkle Science](https://www.merklescience.com/) · [AnChain.AI](https://www.anchain.ai/) · [CryptoAML](https://cryptoaml.ai) (free Telegram bot [@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot), 30+ chains, OFAC/UN/EU sanctions + darknet/mixer detection, no registration)  
 
 ---
 


### PR DESCRIPTION
## Description

Adding [CryptoAML](https://cryptoaml.ai) to the Compliance, Risk & AML section, alongside AMLBot and Scorechain.

**CryptoAML** is a free AML wallet screening tool:
- Available as a Telegram bot ([@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot)) and web interface (cryptoaml.ai)
- Screens against OFAC, UN, and EU sanctions lists, darknet markets, and mixers
- Covers 30+ chains
- No registration required

Minimal one-line change following the existing `·`-separated link format used in this section.